### PR TITLE
Upgrading Jettison orbit bundle version from 1.1.wso2v1 to 1.3.4.wso2v1 ...

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -105,7 +105,7 @@
         <commons-dbcp.osgi.version>1.4.0.wso2v1</commons-dbcp.osgi.version>
         <xmlbeans.osgi.version>2.3.0.wso2v1</xmlbeans.osgi.version>
         <jsr107cache.osgi.version>1.1.wso2v1</jsr107cache.osgi.version>
-        <jettison.osgi.version>1.1.wso2v1</jettison.osgi.version>
+        <jettison.osgi.version>1.3.4.wso2v1</jettison.osgi.version>
         <jdom.osgi.version>1.0.0.wso2v1</jdom.osgi.version>
         <rome.osgi.version>0.9.0.wso2v1</rome.osgi.version>
         <json-simple.osgi.version>1.1.wso2v1</json-simple.osgi.version>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -94,7 +94,7 @@
         <commons-dbcp.osgi.version>1.4.0.wso2v1</commons-dbcp.osgi.version>
         <xmlbeans.osgi.version>2.3.0.wso2v1</xmlbeans.osgi.version>
         <jsr107cache.osgi.version>1.1.wso2v1</jsr107cache.osgi.version>
-        <jettison.osgi.version>1.1.wso2v1</jettison.osgi.version>
+        <jettison.osgi.version>1.3.4.wso2v1</jettison.osgi.version>
         <jdom.osgi.version>1.0.0.wso2v1</jdom.osgi.version>
         <rome.osgi.version>0.9.0.wso2v1</rome.osgi.version>
         <json-simple.osgi.version>1.1.wso2v1</json-simple.osgi.version>


### PR DESCRIPTION
...since CXF webapps requires it.
