### PR TITLE
[DRAFT] Add support for HTTP Basic Auth to http.js

### DIFF
--- a/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/resources/META-INF/scripts/http.js
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/resources/META-INF/scripts/http.js
@@ -38,6 +38,8 @@ var get, post, put, del, head, options, trace, connect;
         var type = typeof url;
         var headers = null;
         var count = args.length;
+        var username = null;
+        var password = null;
         method = method.toUpperCase();
 
         if (count === 0 || count > 5) {
@@ -116,7 +118,7 @@ var get, post, put, del, head, options, trace, connect;
                     throw getError(method, type);
                 }
             }
-        } else if (count === 5) {
+        } else if (count >= 5) {
             if (args[1] != null) {
                 type = typeof args[1];
                 if (type === "object" || string(args[1])) {
@@ -150,6 +152,23 @@ var get, post, put, del, head, options, trace, connect;
                     callback = args[4];
                 } else {
                     throw getError(method, type);
+                }
+            }
+        }
+        // collect username and password
+        if (count === 7) {
+            if (args[5] !== null) {
+                if (string(args[5])) {
+                    username = args[5];
+                } else {
+                    throw getError(method, "argument username must be a string");
+                }
+            }
+            if (args[6] !== null) {
+                if (string(args[6])) {
+                    password = args[6];
+                } else {
+                    throw getError(method, "argument password must be a string");
                 }
             }
         }
@@ -190,7 +209,7 @@ var get, post, put, del, head, options, trace, connect;
                 }
             };
         }
-        xhr.open(method, url, callback !== null);
+        xhr.open(method, url, callback !== null, username, password);
         xhr.send(query);
         return callback !== null ? xhr : {
             data : formatData(xhr, dataType),


### PR DESCRIPTION
This change illustrates the idea of extending get(..), post(..) etc.
with additional username, and password arguments to use the
XMLHttpRequest.open support for basic authentication.

See the thread leading to this idea at

http://markmail.org/message/764yfndieppgekmk
