### PR TITLE
Changing jaggery-extentions suubmodule repo to 1.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "jaggery-extensions"]
 	path = jaggery-extensions
-	url = https://github.com/wso2/jaggery-extensions.git
+	url = https://github.com/ayshsandu/jaggery-extensions.git
 	ignore = dirty

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
 
         <!-- jaggery modules -->
         <caramel.module.version>1.0.1</caramel.module.version>
-        <carbon.module.version>1.0.0</carbon.module.version>
+        <carbon.module.version>1.1.0</carbon.module.version>
         <email.module.version>1.0.0</email.module.version>
         <handlebars.module.version>1.0.0</handlebars.module.version>
         <markdown.module.version>1.0.0</markdown.module.version>
@@ -347,7 +347,7 @@
         <oauth.module.version>1.0.0</oauth.module.version>
         <process.module.version>1.0.0</process.module.version>
         <uuid.module.version>1.0.0</uuid.module.version>
-        <ws.module.version>1.0.0</ws.module.version>
+        <ws.module.version>1.1.0</ws.module.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Sub-module components in jaggery-extensions,
      ws
      jaggery-test
      carbon 
             updated to version 1.1.0  
