### PR TITLE
Adding fix for JAGGERY-392 - Handle regression issues caused by fix on CARBON-14867

### DIFF
--- a/server/integration/tests-integration/src/test/resources/log4j.properties
+++ b/server/integration/tests-integration/src/test/resources/log4j.properties
@@ -65,7 +65,7 @@ log4j.appender.CARBON_CONSOLE.threshold=DEBUG
 
 
 # CARBON_MEMORY is set to be a MemoryAppender using a PatternLayout.
-log4j.appender.CARBON_MEMORY=org.wso2.carbon.logging.appenders.MemoryAppender
+log4j.appender.CARBON_MEMORY=org.wso2.carbon.utils.logging.appenders.MemoryAppender
 log4j.appender.CARBON_MEMORY.layout=org.apache.log4j.PatternLayout
 log4j.appender.CARBON_MEMORY.bufferSize=200
 # ConversionPattern will be overridden by the configuration setting in the DB


### PR DESCRIPTION
As a result of the fix for CARBON-14867,

Following classes in org.wso2.carbon.logging.appenders.\* package have been moved to org.wso2.carbon.utils.logging.appenders.\* package:
CarbonConsoleAppender - overridden subAppend method
CarbonDailyRollingFileAppender - overridden subAppend method
MemoryAppender

Following classses in org.wso2.carbon.logging.\* package have been moved to org.wso2.carbon.utils.logging package.
LoggingUtils - added new method getTenantAwareLogEvent()
CircularBuffer

IMPORTANT: Please not that merging this pull request has a prerequisite merge [1] on carbon4-kernel. Please make sure that change is merged to carbon kernel before merging this.

[1] https://github.com/wso2-dev/carbon4-kernel/pull/57
