### PR TITLE
JAGGERY-406

### DIFF
--- a/features/org.jaggeryjs.server.feature/pom.xml
+++ b/features/org.jaggeryjs.server.feature/pom.xml
@@ -344,7 +344,6 @@
                                 <importBundleDef>jdom.wso2:jdom</importBundleDef>
                                 <importBundleDef>commons-cli.wso2:commons-cli</importBundleDef>
                                 <importBundleDef>com.googlecode.json-simple.wso2:json-simple</importBundleDef>
-                                <importBundleDef>com.google.code.gson:gson</importBundleDef>
                             </importBundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
 
         <commons-io.osgi.version>2.0.0.wso2v1</commons-io.osgi.version>
         <commons-httpclient.osgi.version>3.1.0.wso2v2</commons-httpclient.osgi.version>
-        <gson.osgi.version>2.1</gson.osgi.version>
+        <gson.osgi.version>2.3.1</gson.osgi.version>
         <eclipse-debugger.version>1.0.300.v201109150503</eclipse-debugger.version>
         <eclipse-transport.version>1.0.100.v201109150330</eclipse-transport.version>
         <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>


### PR DESCRIPTION
Removed from ImportBundleDef in features and updated version to 2.3.1 of com.google.code.gson.

Please note that this needs to be merge after upgrading the kernel to 4.4.1 after the pull request for [1] is merged.

[1] - https://github.com/wso2/carbon4-kernel/pull/204