### PR TITLE
Use JSON parser instead of local parser

### DIFF
--- a/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/resources/META-INF/scripts/http.js
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/resources/META-INF/scripts/http.js
@@ -14,7 +14,7 @@ var get, post, put, del, head, options, trace, connect;
         if (type === "xml") {
 			return new XML(data.replace(/<\?xml.*?\?>/, "").replace(/<!--[\s\S]*?-->/g, ""));
 		} else if (type === "json") {
-			return parse(data);
+			return JSON.parse(data);
         } else {
 			return data;
 		}


### PR DESCRIPTION
Changed parse(data) to JSON.parse(data) to avoid integer parsing issue exists with parse(data).