### PR TITLE
WSAS-2055 Deploying jaggery apps to a tenant leads to Illegal access error in CarbonTomcatSessionPersistentManager

### DIFF
--- a/components/jaggery-core/org.jaggeryjs.jaggery.app.mgt/src/main/java/org/jaggeryjs/jaggery/app/mgt/TomcatJaggeryWebappsDeployer.java
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.app.mgt/src/main/java/org/jaggeryjs/jaggery/app/mgt/TomcatJaggeryWebappsDeployer.java
@@ -254,6 +254,11 @@ public class TomcatJaggeryWebappsDeployer extends TomcatGenericWebappsDeployer {
             } else {
                 if (manager instanceof CarbonTomcatSessionManager) {
                     ((CarbonTomcatSessionManager) manager).setOwnerTenantId(tenantId);
+                } else if (manager instanceof CarbonTomcatSessionPersistentManager){
+                    ((CarbonTomcatSessionPersistentManager) manager).setOwnerTenantId(tenantId);
+                    log.debug(manager.getInfo() +
+                             " enabled Tomcat HTTP Session Persistent mode using " +
+                             ((CarbonTomcatSessionPersistentManager) manager).getStore().getInfo());
                 } else {
                     context.setManager(new CarbonTomcatSessionManager(tenantId));
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
         <carbon.identity.version>4.5.1</carbon.identity.version>
         <carbon.registry.imp.pkg.version>[4.4.0, 4.5.0)</carbon.registry.imp.pkg.version>
 
-        <carbon.deployment.version>4.4.0</carbon.deployment.version>
+        <carbon.deployment.version>4.5.0</carbon.deployment.version>
 
         <jaggery.version>0.10.3-SNAPSHOT</jaggery.version>
 


### PR DESCRIPTION
**NOTE: This should be merged after carbon-deployment 4.5.0 is released.**