### PR TITLE
Improved the function 'addSecurityConstraints' in 'TomcatJaggeryWebappsDeployer' to support User-Data-Constraint

### DIFF
--- a/components/jaggery-core/org.jaggeryjs.jaggery.app.mgt/src/main/java/org/jaggeryjs/jaggery/app/mgt/TomcatJaggeryWebappsDeployer.java
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.app.mgt/src/main/java/org/jaggeryjs/jaggery/app/mgt/TomcatJaggeryWebappsDeployer.java
@@ -582,6 +582,16 @@ public class TomcatJaggeryWebappsDeployer extends TomcatGenericWebappsDeployer {
                     securityConstraint.setAuthConstraint(true);
                 }
 
+                if (((JSONObject) o.get(JaggeryCoreConstants.JaggeryConfigParams.SECURITY_CONSTRAINT)).
+                        get(JaggeryCoreConstants.JaggeryConfigParams.USER_DATA_CONSTRAINT) != null) {
+                    JSONObject userDataConstraint = (JSONObject) ((JSONObject) o.get(JaggeryCoreConstants.
+                            JaggeryConfigParams.SECURITY_CONSTRAINT)).
+                            get(JaggeryCoreConstants.JaggeryConfigParams.USER_DATA_CONSTRAINT);
+                    String transportGuarantee = (String) userDataConstraint.get(JaggeryCoreConstants.
+                            JaggeryConfigParams.TRANSPORT_GUARANTEE);
+                    securityConstraint.setUserConstraint(transportGuarantee);
+                }
+
                 context.addConstraint(securityConstraint);
             }
         }

--- a/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/java/org/jaggeryjs/jaggery/core/JaggeryCoreConstants.java
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/java/org/jaggeryjs/jaggery/core/JaggeryCoreConstants.java
@@ -53,6 +53,8 @@ public final class JaggeryCoreConstants {
         public static final String LOG_LEVEL = "logLevel";
         public static final String SESSION_CREATED_LISTENER_SCRIPTS = "sessionCreatedListeners";
         public static final String SESSION_DESTROYED_LISTENER_SCRIPTS = "sessionDestroyedListeners";
+        public static final String USER_DATA_CONSTRAINT = "userDataConstraint";
+        public static final String TRANSPORT_GUARANTEE = "transportGuarantee";
     }
 
 }


### PR DESCRIPTION
For an example, configuration can be defined in the jaggery.conf as follows:

"securityConstraints": [
        {
            "securityConstraint": {
                "webResourceCollection": {
                    "name": "MDM",
                    "urlPatterns": [
                        "/*"
                    ]
                },
                "userDataConstraint": {
                    "transportGuarantee": "CONFIDENTIAL"
                }
            }
      }
]