### PR TITLE
Adding custom log level support on Jaggery Apps

### DIFF
--- a/components/hostobjects/org.jaggeryjs.hostobjects.log/src/main/java/org/jaggeryjs/hostobjects/log/LogHostObject.java
+++ b/components/hostobjects/org.jaggeryjs.hostobjects.log/src/main/java/org/jaggeryjs/hostobjects/log/LogHostObject.java
@@ -95,23 +95,14 @@ public class LogHostObject extends ScriptableObject {
             String requestString = ((Stack<String>) context.getProperty(JAGGERY_INCLUDES_CALLSTACK)).peek();
             loggerName = ROOT_LOGGER + requestString.replace(".jag", ":jag").replace(".js", ":js").replace("/", ".");
         }
-        LogHostObject logObj = new LogHostObject();
-        logObj.logger = Logger.getLogger(loggerName);
 
-        String logLevel = (String) context.getProperty(LOG_LEVEL);
-        if (LOG_LEVEL_FATAL.equalsIgnoreCase(logLevel)) {
-            logObj.logger.setLevel(Level.FATAL);
-        } else if (LOG_LEVEL_WARN.equalsIgnoreCase(logLevel)) {
-            logObj.logger.setLevel(Level.WARN);
-        } else if (LOG_LEVEL_DEBUG.equalsIgnoreCase(logLevel)) {
-            logObj.logger.setLevel(Level.DEBUG);
-        } else if (LOG_LEVEL_ERROR.equalsIgnoreCase(logLevel)) {
-            logObj.logger.setLevel(Level.ERROR);
-        } else if (LOG_LEVEL_TRACE.equalsIgnoreCase(logLevel)) {
-            logObj.logger.setLevel(Level.TRACE);
-        } else {
-            logObj.logger.setLevel(Level.INFO);
+        LogHostObject logObj = new LogHostObject();
+        Logger currentLogger = Logger.getLogger(loggerName);
+        String appLogLevel = (String) context.getProperty(LOG_LEVEL);
+        if(currentLogger.getLevel() == null){
+            currentLogger.setLevel(Level.toLevel(appLogLevel));
         }
+        logObj.logger = currentLogger;
         return logObj;
     }
 


### PR DESCRIPTION
This will add support for custom log levels on Jaggery Apps.

1. If a log level is set by log4j.properties it will get the priority. 
2. Otherwise, new logger will get the application scope log level set by jaggery.conf file.