### PR TITLE
Fixing jaggery App Uploading secuiry issue

### DIFF
--- a/components/jaggery-core/org.jaggeryjs.jaggery.app.mgt.ui/src/main/resources/web/jaggeryapp-mgt/uploadjaggeryapp.jsp
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.app.mgt.ui/src/main/resources/web/jaggeryapp-mgt/uploadjaggeryapp.jsp
@@ -17,6 +17,7 @@
  -->
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://wso2.org/projects/carbon/taglibs/carbontags.jar" prefix="carbon" %>
+<%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>
 
 <!-- This page is included to display messages which are set to request scope or session scope -->
 <jsp:include page="../dialog/display_messages.jsp"/>
@@ -95,7 +96,7 @@
         <h2><fmt:message key="upload.web.application"/></h2>
 
         <div id="workArea">
-            <form method="post" name="webappUploadForm" action="../../fileupload/jaggeryapp"
+            <form method="post" name="webappUploadForm" action="../../fileupload/jaggeryapp?<csrf:tokenname/>=<csrf:tokenvalue/>"
                   enctype="multipart/form-data" target="_self">
                 <input type="hidden" name="errorRedirectionPage"
                             value="../carbon/jaggeryapp-mgt/uploadjaggeryapp.jsp?region=region1&item=webapps_add_menu"/>


### PR DESCRIPTION
## Purpose
Getting the following error when I try to upload the jaggery application through the carbon management console.
[2017-03-16 11:16:49,282] WARN {org.owasp.csrfguard.log.JavaLogger} - potential cross-site request forgery (CSRF) attack thwarted (user:, ip:127.0.0.1, method:POST, uri:/fileupload/jaggeryapp, error:required token is missing from the request)

This PR will fix the above issue

## Goals
Added following taglib which references the OWASP CSRF Guard.
<%@ taglib uri="http://www.owasp.org/index.php/Category:OWASP_CSRFGuard_Project/Owasp.CsrfGuard.tld" prefix="csrf" %>

Then in the HTML form, following parameter should be added in the action. 

<csrf:tokenname/>=<csrf:tokenvalue/>

So, the sample action looks like below.

action="../../fileupload/jaggeryapp?<csrf:tokenname/>=<csrf:tokenvalue/>"