### PR TITLE
Fix potential memory leak in setTimeout() and setInterval()

### DIFF
--- a/components/script-engine/org.jaggeryjs.scriptengine/src/main/java/org/jaggeryjs/scriptengine/engine/RhinoTopLevel.java
+++ b/components/script-engine/org.jaggeryjs.scriptengine/src/main/java/org/jaggeryjs/scriptengine/engine/RhinoTopLevel.java
@@ -120,7 +120,7 @@ public class RhinoTopLevel extends ImporterTopLevel {
         final Function callback = function;
         final ContextFactory factory = cx.getFactory();
         timeout = ((Number) args[1]).longValue();
-        String uuid = UUID.randomUUID().toString();
+        final String uuid = UUID.randomUUID().toString();
 
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
         final int tenantId = carbonContext.getTenantId();
@@ -148,6 +148,7 @@ public class RhinoTopLevel extends ImporterTopLevel {
                 } catch (Exception e) {
                     log.error(e.getMessage(), e);
                 } finally {
+                    clearTimeout(uuid);
                     PrivilegedCarbonContext.endTenantFlow();
                     RhinoEngine.exitContext();
                     currentThread.setContextClassLoader(originalClassLoader);
@@ -292,7 +293,7 @@ public class RhinoTopLevel extends ImporterTopLevel {
         if (tasks == null) {
             return;
         }
-        ScheduledFuture future = tasks.get(taskId);
+        ScheduledFuture future = tasks.remove(taskId);
         future.cancel(true);
     }
 
@@ -302,7 +303,7 @@ public class RhinoTopLevel extends ImporterTopLevel {
         if (tasks == null) {
             return;
         }
-        ScheduledFuture future = tasks.get(taskId);
+        ScheduledFuture future = tasks.remove(taskId);
         future.cancel(true);
     }
 


### PR DESCRIPTION
removeTasks() will be called first on unloadTenant(), which does not
have to happen. So the ScheduledFutures stored in the tasks HashMap
may never be removed. This commit releases the ScheduledFuture on
clearTimeout() / clearInterval() or when the setTimeout() completes.