### PR TITLE
Adding a copy feature without jaggery.tools jar

### DIFF
--- a/features/org.jaggeryjs.jaggery.tools.server.feature/pom.xml
+++ b/features/org.jaggeryjs.jaggery.tools.server.feature/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.jaggeryjs</groupId>
         <artifactId>features</artifactId>
-        <version>0.14.2-SNAPSHOT</version>
+        <version>0.14.13-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -26,8 +26,7 @@
     <packaging>pom</packaging>
     <name>Jaggery Server tools Feature</name>
     <url>http://wso2.org</url>
-    <description>This feature contains the jaggery tool bundles required for jaggery functionality
-    </description>
+    <description>This feature contains the jaggery tool bundles required for jaggery functionality</description>
     <dependencies>
         <dependency>
             <groupId>org.jaggeryjs</groupId>

--- a/features/org.jaggeryjs.jaggery.tools.server.feature/pom.xml
+++ b/features/org.jaggeryjs.jaggery.tools.server.feature/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ ~ Copyright (c) 2009-2011, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~      http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.jaggeryjs</groupId>
+        <artifactId>features</artifactId>
+        <version>0.14.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.jaggeryjs.jaggery.tools.server.feature</artifactId>
+    <packaging>pom</packaging>
+    <name>Jaggery Server tools Feature</name>
+    <url>http://wso2.org</url>
+    <description>This feature contains the jaggery tool bundles required for jaggery functionality
+    </description>
+    <dependencies>
+        <dependency>
+            <groupId>org.jaggeryjs</groupId>
+            <artifactId>org.jaggeryjs.jaggery.tools</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prefilter-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>src/main/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>resources</directory>
+                                    <includes>
+                                        <include>p2.inf</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>../../</directory>
+                                    <includes>
+                                        <include>modules/**</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>org.jaggeryjs.jaggery.tools.server</id>
+                            <propertiesFile>../etc/feature.properties</propertiesFile>
+                            <bundles>
+                                <bundleDef>org.jaggeryjs:org.jaggeryjs.jaggery.tools</bundleDef>
+                            </bundles>
+                            <importFeatures>
+                                <importFeatureDef>org.wso2.carbon.registry.core.server:compatible:${carbon.kernel.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.registry.core.common:compatible:${carbon.kernel.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.registry.contentsearch.server:compatible:${carbon.registry.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.common:compatible:${carbon.kernel.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${carbon.identity.version}</importFeatureDef>
+                            </importFeatures>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean_target</id>
+                        <phase>install</phase>
+                        <configuration>
+                            <tasks>
+                                <delete dir="src/main/resources" />
+                                <delete dir="src/main" />
+                                <delete dir="src" />
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/features/org.jaggeryjs.jaggery.tools.server.feature/pom.xml
+++ b/features/org.jaggeryjs.jaggery.tools.server.feature/pom.xml
@@ -14,7 +14,6 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.jaggeryjs</groupId>

--- a/features/org.jaggeryjs.jaggery.tools.server.feature/resources/p2.inf
+++ b/features/org.jaggeryjs.jaggery.tools.server.feature/resources/p2.inf
@@ -1,0 +1,1 @@
+instructions.configure = \

--- a/features/org.jaggeryjs.server.feature/pom.xml
+++ b/features/org.jaggeryjs.server.feature/pom.xml
@@ -27,8 +27,8 @@
     <packaging>pom</packaging>
     <name>Jaggery Server Feature</name>
     <url>http://wso2.org</url>
-    <description>This feature contains the core bundles required for jaggery
-        functionality
+
+    <description>This feature contains the core bundles required for jaggery functionality without jaggery.tools dependency
     </description>
     <dependencies>
         <dependency>
@@ -62,10 +62,6 @@
         <dependency>
             <groupId>org.wso2.apache.solr</groupId>
             <artifactId>solr</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jaggeryjs</groupId>
-            <artifactId>org.jaggeryjs.jaggery.tools</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jaggeryjs</groupId>
@@ -296,7 +292,6 @@
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.jaggery.deployer</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.jaggery.core</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.jaggery.app.mgt</bundleDef>
-                                <bundleDef>org.jaggeryjs:org.jaggeryjs.jaggery.tools</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.scriptengine</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.registry</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.web</bundleDef>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -31,5 +31,6 @@
         <module>org.jaggeryjs.server.feature</module>
         <module>org.jaggeryjs.ui.feature</module>
         <module>org.jaggeryjs.feature</module>
+        <module>org.jaggeryjs.jaggery.tools.server.feature</module>
     </modules>
 </project>


### PR DESCRIPTION
## Purpose
Resolves wso2/product-apim#8915

Remove org.jaggeryjs.jaggery.tools_XXX.jar from org.jaggeryjs.server.feature feature and a add new feature of org.jaggeryjs.jaggery.tools.server.feature to add the removed jar.