### PR TITLE
Remove rome and feed from jaggery

### DIFF
--- a/components/hostobjects/pom.xml
+++ b/components/hostobjects/pom.xml
@@ -36,7 +36,6 @@
         <module>org.jaggeryjs.hostobjects.xhr</module>
         <module>org.jaggeryjs.hostobjects.xslt</module>
         <module>org.jaggeryjs.hostobjects.oauth</module>
-        <module>org.jaggeryjs.hostobjects.feed</module>
         <module>org.jaggeryjs.hostobjects.uri</module>
         <module>org.jaggeryjs.hostobjects.log</module>
         <module>org.jaggeryjs.hostobjects.jaggeryparser</module>

--- a/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/resources/META-INF/module.xml
+++ b/components/jaggery-core/org.jaggeryjs.jaggery.core/src/main/resources/META-INF/module.xml
@@ -36,14 +36,6 @@
         <className>org.jaggeryjs.hostobjects.file.FileHostObject</className>
         <name>File</name>
     </hostObject>
-    <hostObject>
-        <className>org.jaggeryjs.hostobjects.feed.EntryHostObject</className>
-        <name>Entry</name>
-    </hostObject>
-    <hostObject>
-        <className>org.jaggeryjs.hostobjects.feed.FeedHostObject</className>
-        <name>Feed</name>
-    </hostObject>
 
     <hostObject>
         <className>org.jaggeryjs.hostobjects.web.RequestHostObject</className>

--- a/features/org.jaggeryjs.server.feature/pom.xml
+++ b/features/org.jaggeryjs.server.feature/pom.xml
@@ -105,10 +105,6 @@
         </dependency>
         <dependency>
             <groupId>org.jaggeryjs</groupId>
-            <artifactId>org.jaggeryjs.hostobjects.feed</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jaggeryjs</groupId>
             <artifactId>org.jaggeryjs.hostobjects.jaggeryparser</artifactId>
         </dependency>
         <dependency>
@@ -190,10 +186,6 @@
         <dependency>
             <groupId>org.apache.rampart.wso2</groupId>
             <artifactId>rampart-trust</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>rome.wso2</groupId>
-            <artifactId>rome</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scribe</groupId>
@@ -299,7 +291,6 @@
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.stream</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.xhr</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.db</bundleDef>
-                                <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.feed</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.xslt</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.uri</bundleDef>
                                 <bundleDef>org.jaggeryjs:org.jaggeryjs.hostobjects.jaggeryparser</bundleDef>
@@ -311,7 +302,6 @@
                                 </importBundleDef>
                                 <importBundleDef>org.eclipse.wst.jsdt:org.eclipse.wst.jsdt.debug.transport
                                 </importBundleDef>
-                                <importBundleDef>rome.wso2:rome</importBundleDef>
                                 <importBundleDef>org.wso2.uri.template:wso2-uri-templates</importBundleDef>
                                 <importBundleDef>net.sf.saxon.wso2:saxon.bps</importBundleDef>
                                 <importBundleDef>jdom.wso2:jdom</importBundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,6 @@
         <tomcat.osgi.version>9.0.21.wso2v1</tomcat.osgi.version>
         <scribe.version>1.3.1</scribe.version>
         <jdom.osgi.version>1.0.0.wso2v1</jdom.osgi.version>
-        <rome.osgi.version>0.9.0.wso2v1</rome.osgi.version>
         <abdera.osgi.version>1.0.0.wso2v3</abdera.osgi.version>
         <abdera-extensions.osgi.version>0.4.0.wso2v2</abdera-extensions.osgi.version>
         <findbugs-annotations.version>3.0.1</findbugs-annotations.version>
@@ -600,11 +599,6 @@
                 <groupId>jdom.wso2</groupId>
                 <artifactId>jdom</artifactId>
                 <version>${jdom.osgi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>rome.wso2</groupId>
-                <artifactId>rome</artifactId>
-                <version>${rome.osgi.version}</version>
             </dependency>
             <!--<dependency>
                 <groupId>org.wso2.carbon</groupId>


### PR DESCRIPTION
## Purpose
This PR removes `rome` `v0.9` dependency and `org.jaggeryjs.hostobjects.feed` module from jaggery since these are no longer used in APIM and IS products.